### PR TITLE
feat: add lightweight workflow control panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
 # Hello-world
-first time use github
-I'm studying Node.js
+
+一个轻量的流程控制面板示例，提供以下能力：
+
+- 展示流程名称、运行状态和执行进度
+- 支持启动、暂停、重置流程
+- 提供事件日志并支持清空
+
+## 本地运行
+
+```bash
+python3 -m http.server 8000
+```
+
+然后访问 `http://localhost:8000`。

--- a/index.html
+++ b/index.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>轻量流程控制面板</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <main class="panel">
+      <header class="panel__header">
+        <h1>流程控制面板</h1>
+        <p>适用于小型自动化任务的状态监控与流程控制。</p>
+      </header>
+
+      <section class="status-grid">
+        <article class="status-card">
+          <h2>当前流程</h2>
+          <p id="flow-name">数据同步任务</p>
+        </article>
+        <article class="status-card">
+          <h2>运行状态</h2>
+          <p id="flow-state" class="state state--idle">待机</p>
+        </article>
+        <article class="status-card">
+          <h2>执行进度</h2>
+          <div class="progress-wrap" aria-label="执行进度">
+            <div id="progress-bar" class="progress-bar"></div>
+          </div>
+          <p id="progress-text">0%</p>
+        </article>
+      </section>
+
+      <section class="controls">
+        <button id="start-btn" class="btn btn--primary" type="button">启动</button>
+        <button id="pause-btn" class="btn" type="button" disabled>暂停</button>
+        <button id="reset-btn" class="btn" type="button">重置</button>
+      </section>
+
+      <section class="log-section">
+        <div class="log-section__head">
+          <h2>事件日志</h2>
+          <button id="clear-log-btn" class="btn btn--text" type="button">清空</button>
+        </div>
+        <ul id="event-log" class="event-log" aria-live="polite"></ul>
+      </section>
+    </main>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,91 @@
+const stateElement = document.getElementById("flow-state");
+const progressBar = document.getElementById("progress-bar");
+const progressText = document.getElementById("progress-text");
+const eventLog = document.getElementById("event-log");
+
+const startBtn = document.getElementById("start-btn");
+const pauseBtn = document.getElementById("pause-btn");
+const resetBtn = document.getElementById("reset-btn");
+const clearLogBtn = document.getElementById("clear-log-btn");
+
+let timer = null;
+let progress = 0;
+let runState = "idle";
+
+function writeLog(message) {
+  const item = document.createElement("li");
+  const time = new Date().toLocaleTimeString("zh-CN", { hour12: false });
+  item.textContent = `[${time}] ${message}`;
+  eventLog.prepend(item);
+}
+
+function render() {
+  progressBar.style.width = `${progress}%`;
+  progressText.textContent = `${progress}%`;
+
+  stateElement.className = "state";
+  if (runState === "running") {
+    stateElement.classList.add("state--running");
+    stateElement.textContent = "运行中";
+  } else if (runState === "paused") {
+    stateElement.classList.add("state--paused");
+    stateElement.textContent = "已暂停";
+  } else {
+    stateElement.classList.add("state--idle");
+    stateElement.textContent = "待机";
+  }
+
+  startBtn.disabled = runState === "running";
+  pauseBtn.disabled = runState !== "running";
+}
+
+function startFlow() {
+  if (runState === "running") {
+    return;
+  }
+  runState = "running";
+  writeLog("流程已启动");
+  timer = setInterval(() => {
+    progress = Math.min(progress + 5, 100);
+    if (progress >= 100) {
+      clearInterval(timer);
+      timer = null;
+      runState = "idle";
+      writeLog("流程执行完成");
+    }
+    render();
+  }, 650);
+  render();
+}
+
+function pauseFlow() {
+  if (runState !== "running") {
+    return;
+  }
+  clearInterval(timer);
+  timer = null;
+  runState = "paused";
+  writeLog("流程已暂停");
+  render();
+}
+
+function resetFlow() {
+  clearInterval(timer);
+  timer = null;
+  progress = 0;
+  runState = "idle";
+  writeLog("流程已重置");
+  render();
+}
+
+startBtn.addEventListener("click", startFlow);
+pauseBtn.addEventListener("click", pauseFlow);
+resetBtn.addEventListener("click", resetFlow);
+
+clearLogBtn.addEventListener("click", () => {
+  eventLog.innerHTML = "";
+  writeLog("日志已清空");
+});
+
+writeLog("面板已就绪");
+render();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,169 @@
+:root {
+  color-scheme: light;
+  font-family: "PingFang SC", "Microsoft YaHei", system-ui, -apple-system, sans-serif;
+  --bg: #f5f7fb;
+  --card: #ffffff;
+  --text: #15213a;
+  --muted: #5d6b86;
+  --primary: #377dff;
+  --border: #dbe3f1;
+  --success: #16a34a;
+  --warning: #f59e0b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.panel {
+  width: min(920px, 92vw);
+  margin: 3rem auto;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1.2rem;
+  box-shadow: 0 10px 24px rgba(20, 40, 90, 0.08);
+}
+
+.panel__header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.panel__header p {
+  margin: 0.35rem 0 1rem;
+  color: var(--muted);
+}
+
+.status-grid {
+  display: grid;
+  gap: 0.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+}
+
+.status-card {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.75rem;
+  background: #fcfdff;
+}
+
+.status-card h2 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.status-card p {
+  margin: 0.55rem 0 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.state {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.state::before {
+  content: "";
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: var(--muted);
+}
+
+.state--running::before {
+  background: var(--success);
+}
+
+.state--paused::before {
+  background: var(--warning);
+}
+
+.progress-wrap {
+  margin-top: 0.55rem;
+  height: 10px;
+  background: #e6ecf8;
+  border-radius: 99px;
+  overflow: hidden;
+}
+
+.progress-bar {
+  width: 0%;
+  height: 100%;
+  background: linear-gradient(90deg, #377dff, #2ec5ff);
+  transition: width 0.25s ease;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin: 1rem 0;
+}
+
+.btn {
+  border: 1px solid var(--border);
+  background: #fff;
+  color: var(--text);
+  padding: 0.55rem 1rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.btn--primary {
+  border-color: transparent;
+  background: var(--primary);
+  color: #fff;
+}
+
+.btn--text {
+  padding: 0;
+  border: none;
+  color: var(--primary);
+}
+
+.log-section {
+  border-top: 1px solid var(--border);
+  padding-top: 1rem;
+}
+
+.log-section__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.log-section__head h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.event-log {
+  list-style: none;
+  margin: 0.75rem 0 0;
+  padding: 0;
+  max-height: 220px;
+  overflow: auto;
+}
+
+.event-log li {
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed #e6ecf8;
+  color: #273654;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
### Motivation
- Provide a small, self-contained frontend panel for monitoring and controlling simple automation flows with an easy local demo and no backend dependencies.

### Description
- Add `index.html` implementing the panel layout with status cards, control buttons, progress bar and event log.
- Add `style.css` providing the visual design for cards, state indicators, progress and controls.
- Add `script.js` implementing start/pause/reset behavior, simulated progress advancement and timestamped event logging.
- Update `README.md` with a project description and instructions to run the demo locally using `python3 -m http.server`.

### Testing
- Ran `node --check script.js` which succeeded.
- Served the files with `python3 -m http.server 8000 --bind 127.0.0.1` and verified `curl -I http://127.0.0.1:8000/index.html` returned `HTTP/1.0 200 OK`.
- Captured a visual verification screenshot via Playwright which produced the artifact `artifacts/panel.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699db4d408908327adad3e07645a3e2b)