### PR TITLE
feat: 新增 Vite React TypeScript 驗證範例（MSW mock、Protected Route、RBAC）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_USE_MSW=true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,50 @@
-# Hello-world
-first time use github
-I'm studying Node.js
+# Vite + React + TypeScript Auth Demo
+
+包含：登入流程、JWT token（localStorage）、Protected Route、RBAC、MSW mock server、axios API。
+
+## 安裝
+```bash
+npm install
+```
+
+## 啟動（dev + MSW）
+```bash
+cp .env.example .env
+npm run dev
+```
+> 需設定 `VITE_USE_MSW=true` 才會在 `src/main.tsx` 啟用 MSW。
+
+## 測試
+```bash
+npm run test
+```
+
+## 手動測試流程清單
+1. **success**
+   - 面板情境選 `login:success`。
+   - `/login` 輸入合法帳密後登入，應導向 `/dashboard` 並顯示歡迎與商品。
+2. **401（登入失敗）**
+   - 面板切 `login:invalid_password` 或 `login:email_not_found`。
+   - 驗證錯誤訊息為中文。
+3. **403 / 權限不足（RBAC）**
+   - 用一般 user 登入（email 不含 admin）。
+   - 手動前往 `/admin`，應被導回 `/dashboard`。
+4. **expired**
+   - 先登入成功，再把情境切成 `me:token_expired`。
+   - 重整 `/dashboard`，應清 token、導回 `/login` 且顯示過期訊息。
+5. **delay / loading**
+   - 面板延遲切為 `500` 或 `1000`。
+   - 重新觸發登入或進 dashboard，觀察 loading 畫面。
+6. **500 + retry**
+   - `me:server_error` 或 `products:server_error`，應顯示錯誤。
+   - 切回 success 後重整重試。
+
+## Dev 手動測試面板
+右下角浮窗（僅 dev）：
+- 切換 API 情境（login/me/products）
+- 切換延遲 0 / 0.5s / 1s
+- 一鍵清除 token
+
+MSW handler 會從 localStorage 讀取：
+- `msw_scenario`
+- `msw_delay`

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Auth Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "hello-world-auth-demo",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "axios": "^1.9.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.30.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "@vitejs/plugin-react": "^4.4.1",
+    "msw": "^2.10.3",
+    "typescript": "~5.8.3",
+    "vite": "^5.4.19",
+    "vitest": "^2.1.9"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,27 @@
+import { Link, Navigate, Route, Routes } from 'react-router-dom';
+import { AuthProvider } from './authContext';
+import { DevPanel } from './components/DevPanel';
+import { ProtectedRoute } from './components/ProtectedRoute';
+import { RoleGuard } from './components/RoleGuard';
+import { AdminPage } from './pages/AdminPage';
+import { DashboardPage } from './pages/DashboardPage';
+import { LoginPage } from './pages/LoginPage';
+
+export const App = () => {
+  return (
+    <AuthProvider>
+      <nav>
+        <Link to="/login">Login</Link>
+        <Link to="/dashboard">Dashboard</Link>
+        <Link to="/admin">Admin</Link>
+      </nav>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/dashboard" element={<ProtectedRoute><DashboardPage /></ProtectedRoute>} />
+        <Route path="/admin" element={<ProtectedRoute><RoleGuard allowed={['admin']}><AdminPage /></RoleGuard></ProtectedRoute>} />
+        <Route path="*" element={<Navigate to="/login" replace />} />
+      </Routes>
+      <DevPanel />
+    </AuthProvider>
+  );
+};

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+import { authStorage } from './auth';
+
+export const api = axios.create({ baseURL: '/api' });
+
+api.interceptors.request.use((config) => {
+  const token = authStorage.getToken();
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,13 @@
+const TOKEN_KEY = 'access_token';
+
+export const authStorage = {
+  setToken(token: string) {
+    localStorage.setItem(TOKEN_KEY, token);
+  },
+  getToken() {
+    return localStorage.getItem(TOKEN_KEY);
+  },
+  clearToken() {
+    localStorage.removeItem(TOKEN_KEY);
+  }
+};

--- a/src/authContext.tsx
+++ b/src/authContext.tsx
@@ -1,0 +1,41 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { api } from './api';
+import { authStorage } from './auth';
+import type { User } from './types';
+
+interface AuthContextValue {
+  user: User | null;
+  setUser: (user: User | null) => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null);
+
+  const logout = () => {
+    authStorage.clearToken();
+    setUser(null);
+  };
+
+  useEffect(() => {
+    api.interceptors.response.use(
+      (response) => response,
+      (error) => {
+        if (error.response?.status === 401) {
+          logout();
+        }
+        return Promise.reject(error);
+      }
+    );
+  }, []);
+
+  return <AuthContext.Provider value={{ user, setUser, logout }}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('AuthContext not found');
+  return ctx;
+};

--- a/src/components/DevPanel.tsx
+++ b/src/components/DevPanel.tsx
@@ -1,0 +1,44 @@
+import { authStorage } from '../auth';
+
+const scenarioKey = 'msw_scenario';
+const delayKey = 'msw_delay';
+
+const options = [
+  'login:success',
+  'login:invalid_password',
+  'login:email_not_found',
+  'login:server_error',
+  'me:success',
+  'me:token_expired',
+  'me:server_error',
+  'products:success',
+  'products:server_error'
+];
+
+export const DevPanel = () => {
+  if (!import.meta.env.DEV) return null;
+
+  const update = (key: string, value: string) => {
+    localStorage.setItem(key, value);
+    window.location.reload();
+  };
+
+  return (
+    <div className="dev-panel">
+      <h4>MSW 測試面板</h4>
+      <label>情境</label>
+      <select defaultValue={localStorage.getItem(scenarioKey) ?? 'login:success'} onChange={(e) => update(scenarioKey, e.target.value)}>
+        {options.map((op) => (
+          <option key={op} value={op}>{op}</option>
+        ))}
+      </select>
+      <label>延遲</label>
+      <select defaultValue={localStorage.getItem(delayKey) ?? '0'} onChange={(e) => update(delayKey, e.target.value)}>
+        <option value="0">0s</option>
+        <option value="500">0.5s</option>
+        <option value="1000">1s</option>
+      </select>
+      <button onClick={() => { authStorage.clearToken(); window.location.reload(); }}>清除 Token</button>
+    </div>
+  );
+};

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,13 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import { authStorage } from '../auth';
+
+export const ProtectedRoute = ({ children }: { children: JSX.Element }) => {
+  const token = authStorage.getToken();
+  const location = useLocation();
+
+  if (!token) {
+    return <Navigate to="/login" state={{ from: location.pathname }} replace />;
+  }
+
+  return children;
+};

--- a/src/components/RoleGuard.tsx
+++ b/src/components/RoleGuard.tsx
@@ -1,0 +1,12 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../authContext';
+
+export const RoleGuard = ({ allowed, children }: { allowed: Array<'admin' | 'user'>; children: JSX.Element }) => {
+  const { user } = useAuth();
+
+  if (!user || !allowed.includes(user.role)) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return children;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { App } from './App';
+import './styles.css';
+
+async function startApp() {
+  if (import.meta.env.DEV && import.meta.env.VITE_USE_MSW === 'true') {
+    const { worker } = await import('./mocks/browser');
+    await worker.start({ onUnhandledRequest: 'bypass' });
+  }
+
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </React.StrictMode>
+  );
+}
+
+startApp();

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from 'msw/browser';
+import { handlers } from './handlers';
+
+export const worker = setupWorker(...handlers);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,0 +1,45 @@
+import { delay, http, HttpResponse } from 'msw';
+
+const products = Array.from({ length: 10 }, (_, i) => ({
+  id: i + 1,
+  name: `商品名稱 ${i + 1}`,
+  price: (i + 1) * 100,
+  description: `商品描述 ${i + 1}`
+}));
+
+const readScenario = (prefix: 'login' | 'me' | 'products') => {
+  const raw = localStorage.getItem('msw_scenario') ?? `${prefix}:success`;
+  return raw.startsWith(`${prefix}:`) ? raw.split(':')[1] : 'success';
+};
+
+const readDelay = () => Number(localStorage.getItem('msw_delay') ?? '0');
+
+export const handlers = [
+  http.post('/api/login', async ({ request }) => {
+    await delay(readDelay());
+    const scenario = readScenario('login');
+    const body = (await request.json()) as { email: string };
+    if (scenario === 'invalid_password') return HttpResponse.json({ message: '密碼錯誤' }, { status: 401 });
+    if (scenario === 'email_not_found') return HttpResponse.json({ message: '帳號不存在' }, { status: 401 });
+    if (scenario === 'server_error') return HttpResponse.json({ message: '伺服器錯誤，請稍後再試' }, { status: 500 });
+    return HttpResponse.json({ accessToken: 'fake.jwt.token', user: { username: 'dean', role: body.email.includes('admin') ? 'admin' : 'user' } });
+  }),
+  http.get('/api/me', async ({ request }) => {
+    await delay(readDelay());
+    const auth = request.headers.get('Authorization');
+    if (!auth) return HttpResponse.json({ message: '未授權，請重新登入' }, { status: 401 });
+    const scenario = readScenario('me');
+    if (scenario === 'token_expired') return HttpResponse.json({ message: '登入已過期，請重新登入' }, { status: 401 });
+    if (scenario === 'server_error') return HttpResponse.json({ message: '伺服器錯誤，請稍後再試' }, { status: 500 });
+    return HttpResponse.json({ username: 'dean', role: auth.includes('admin') ? 'admin' : 'user' });
+  }),
+  http.get('/api/products', async ({ request }) => {
+    await delay(readDelay());
+    const auth = request.headers.get('Authorization');
+    if (!auth) return HttpResponse.json({ message: '未授權，請重新登入' }, { status: 401 });
+    const scenario = readScenario('products');
+    if (scenario === 'token_expired') return HttpResponse.json({ message: '登入已過期，請重新登入' }, { status: 401 });
+    if (scenario === 'server_error') return HttpResponse.json({ message: '伺服器錯誤，請稍後再試' }, { status: 500 });
+    return HttpResponse.json({ products });
+  })
+];

--- a/src/mocks/scenario.ts
+++ b/src/mocks/scenario.ts
@@ -1,0 +1,7 @@
+export const getScenario = (prefix: 'login' | 'me' | 'products') => {
+  const raw = localStorage.getItem('msw_scenario') ?? `${prefix}:success`;
+  if (raw.startsWith(`${prefix}:`)) return raw.split(':')[1];
+  return 'success';
+};
+
+export const getDelay = () => Number(localStorage.getItem('msw_delay') ?? '0');

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from 'msw/node';
+import { handlers } from './handlers';
+
+export const server = setupServer(...handlers);

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,0 +1,12 @@
+import { useAuth } from '../authContext';
+
+export const AdminPage = () => {
+  const { user } = useAuth();
+  return (
+    <div className="card">
+      <h1>Admin 控制台</h1>
+      <p>目前角色：{user?.role}</p>
+      <p>你擁有管理者權限，可檢視此頁內容。</p>
+    </div>
+  );
+};

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,0 +1,56 @@
+import { AxiosError } from 'axios';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { api } from '../api';
+import { authStorage } from '../auth';
+import { useAuth } from '../authContext';
+import type { Product, User } from '../types';
+
+export const DashboardPage = () => {
+  const { user, setUser } = useAuth();
+  const [products, setProducts] = useState<Product[]>([]);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const me = await api.get<User>('/me');
+        setUser(me.data);
+        const res = await api.get<{ products: Product[] }>('/products');
+        setProducts(res.data.products.slice(0, 3));
+      } catch (err) {
+        const apiError = err as AxiosError<{ message?: string }>;
+        if (apiError.response?.status === 401) {
+          authStorage.clearToken();
+          navigate('/login', { state: { expired: true } });
+          return;
+        }
+        setError(apiError.response?.data?.message ?? '讀取失敗');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [navigate, setUser]);
+
+  if (loading) return <div className="card">Loading...</div>;
+
+  return (
+    <div className="card">
+      <h1>Welcome, {user?.username ?? 'user'}</h1>
+      <h2>商品列表</h2>
+      {error && <p className="error">{error}</p>}
+      <div className="products">
+        {products.map((p) => (
+          <article key={p.id}>
+            <h3>{p.name}</h3>
+            <p>{p.description}</p>
+            <strong>${p.price}</strong>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,53 @@
+import { AxiosError } from 'axios';
+import { FormEvent, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { api } from '../api';
+import { authStorage } from '../auth';
+import { useAuth } from '../authContext';
+import type { User } from '../types';
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/;
+
+export const LoginPage = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { setUser } = useAuth();
+  const [email, setEmail] = useState('dean@example.com');
+  const [password, setPassword] = useState('abc12345');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!emailRegex.test(email)) return setError('請輸入正確 Email 格式');
+    if (!passwordRegex.test(password)) return setError('密碼需至少 8 碼且包含英文字母與數字');
+
+    setLoading(true);
+    setError('');
+    try {
+      const response = await api.post<{ accessToken: string; user: User }>('/login', { email, password });
+      authStorage.setToken(response.data.accessToken);
+      setUser(response.data.user);
+      navigate('/dashboard');
+    } catch (err) {
+      const apiError = err as AxiosError<{ message?: string }>;
+      setError(apiError.response?.data?.message ?? '登入失敗，請稍後再試');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="card">
+      <h1>登入</h1>
+      {location.state?.expired && <p className="error">登入已過期，請重新登入</p>}
+      <form onSubmit={onSubmit} className="form">
+        <input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" />
+        <input value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" type="password" />
+        <button disabled={loading}>{loading ? '登入中...' : '登入'}</button>
+      </form>
+      {error && <p className="error">{error}</p>}
+    </div>
+  );
+};

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,14 @@
+:root { font-family: Inter, sans-serif; color: #f5f5f5; background: linear-gradient(120deg,#20243c,#0f111a); }
+body { margin: 0; min-height: 100vh; }
+#root { max-width: 960px; margin: 0 auto; padding: 32px 16px; }
+nav { display:flex; gap:12px; margin-bottom: 20px; }
+a { color:#9ad5ff; }
+.card { background: rgba(255,255,255,0.08); border:1px solid rgba(255,255,255,0.12); border-radius:16px; padding:24px; backdrop-filter: blur(10px); }
+.form { display:flex; flex-direction:column; gap:12px; }
+input,button,select { border-radius:10px; border:1px solid #46517c; padding:10px 12px; font-size:14px; }
+button { background:#6a7dff; color:white; border:none; cursor:pointer; }
+.error { color:#ffb8b8; }
+.products { display:grid; grid-template-columns:repeat(3,1fr); gap:12px; }
+.products article { background:#1b2040; border-radius:12px; padding:12px; }
+.dev-panel { position:fixed; right:16px; bottom:16px; width:220px; background:#141a33; border:1px solid #2b376b; border-radius:12px; padding:10px; display:flex; flex-direction:column; gap:8px; }
+.dev-panel h4 { margin:0; font-size:14px; }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,7 @@
+import '@testing-library/jest-dom';
+import { afterAll, afterEach, beforeAll } from 'vitest';
+import { server } from '../mocks/server';
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,13 @@
+export type Role = 'admin' | 'user';
+
+export interface User {
+  username: string;
+  role: Role;
+}
+
+export interface Product {
+  id: number;
+  name: string;
+  price: number;
+  description: string;
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts", "vitest.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts']
+  }
+});


### PR DESCRIPTION
### Motivation
- 提供一個開發用的前端示範專案，展示登入流程、JWT（localStorage）保存、Protected Route 與 role-based 權限控制。 
- 使用 MSW 模擬 API 讓開發與手動測試可控且可重現失敗/延遲情境，並在生產環境關閉 mock（以環境變數控制）。

### Description
- 新增 Vite + React + TypeScript 專案骨架與設定檔，包含 `package.json`、`vite.config.ts`、`tsconfig.*`、`vitest.config.ts` 與入口 `index.html`。 
- 實作認證基礎與 API 客戶端：`src/auth.ts` 用於 `localStorage` token 操作、`src/api.ts` 使用 `axios` 並自動將 token 放入 `Authorization` header、`src/authContext.tsx` 提供 `AuthProvider` 並對 401 做自動登出處理。 
- 實作 UI 與路由保護：`/login`（`src/pages/LoginPage.tsx`）含 Email/密碼格式驗證與 loading、`/dashboard`（`src/pages/DashboardPage.tsx`）在進入時呼叫 `/api/me` 與 `/api/products` 並顯示前三項商品、`/admin`（`src/pages/AdminPage.tsx`）由 `RoleGuard`（`src/components/RoleGuard.tsx`）與 `ProtectedRoute`（`src/components/ProtectedRoute.tsx`）保護以實現 RBAC。 
- 實作 MSW mock 與開發面板：`src/mocks/handlers.ts`、`src/mocks/browser.ts`、`src/mocks/server.ts` 實現 `POST /api/login`、`GET /api/me`、`GET /api/products`（支援 success / 401 / token_expired / 500），且回傳至少 10 筆商品，所有 API 支援延遲；`src/components/DevPanel.tsx` 為 dev-only 右下角面板可切換 `msw_scenario` 與 `msw_delay` 以及清 token；`src/main.tsx` 以 `VITE_USE_MSW=true` 控制在 dev 啟動 MSW。 
- 新增測試設定：`src/test/setup.ts` 使用 `msw/node` 的 `setupServer` 為 vitest 測試環境準備 mock server，並在 `README.md` 說明安裝、啟動（含啟用 MSW 的步驟）與手動測試流程細節。 

### Testing
- 已加入 `vitest` 的 setup（`src/test/setup.ts`）以在測試環境啟動 MSW server 作為自動化測試的基礎，但實際測試尚未執行。 
- 在此執行環境嘗試執行 `npm install` 時遭遇 npm registry 回傳 `403 Forbidden`，導致無法安裝相依並因此未能執行 `npm run test`（自動化測試未執行）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f563b240b4832796e9c008f3f48979)