### PR TITLE
feat: add draggable workflow modeling canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,46 +3,35 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>轻量流程控制面板</title>
+    <title>工作流建模画面</title>
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <main class="panel">
-      <header class="panel__header">
-        <h1>流程控制面板</h1>
-        <p>适用于小型自动化任务的状态监控与流程控制。</p>
+    <main class="workflow-app">
+      <header class="app-header">
+        <h1>工作流模型画面</h1>
+        <p>从左侧拖拽控件到画布，快速搭建流程。</p>
       </header>
 
-      <section class="status-grid">
-        <article class="status-card">
-          <h2>当前流程</h2>
-          <p id="flow-name">数据同步任务</p>
-        </article>
-        <article class="status-card">
-          <h2>运行状态</h2>
-          <p id="flow-state" class="state state--idle">待机</p>
-        </article>
-        <article class="status-card">
-          <h2>执行进度</h2>
-          <div class="progress-wrap" aria-label="执行进度">
-            <div id="progress-bar" class="progress-bar"></div>
+      <section class="layout">
+        <aside class="toolbox" aria-label="控件工具箱">
+          <h2>控件库</h2>
+          <div class="toolbox-list">
+            <button class="tool" type="button" draggable="true" data-type="start">开始</button>
+            <button class="tool" type="button" draggable="true" data-type="task">任务</button>
+            <button class="tool" type="button" draggable="true" data-type="decision">判断</button>
+            <button class="tool" type="button" draggable="true" data-type="end">结束</button>
           </div>
-          <p id="progress-text">0%</p>
-        </article>
-      </section>
+          <p class="hint">提示：拖动后可再次拖动画布中的节点调整位置。</p>
+        </aside>
 
-      <section class="controls">
-        <button id="start-btn" class="btn btn--primary" type="button">启动</button>
-        <button id="pause-btn" class="btn" type="button" disabled>暂停</button>
-        <button id="reset-btn" class="btn" type="button">重置</button>
-      </section>
-
-      <section class="log-section">
-        <div class="log-section__head">
-          <h2>事件日志</h2>
-          <button id="clear-log-btn" class="btn btn--text" type="button">清空</button>
+        <div class="canvas-wrap">
+          <div class="canvas-head">
+            <h2>流程画布</h2>
+            <button id="clear-btn" class="clear-btn" type="button">清空画布</button>
+          </div>
+          <div id="canvas" class="canvas" aria-label="工作流建模画布"></div>
         </div>
-        <ul id="event-log" class="event-log" aria-live="polite"></ul>
       </section>
     </main>
 

--- a/script.js
+++ b/script.js
@@ -1,91 +1,91 @@
-const stateElement = document.getElementById("flow-state");
-const progressBar = document.getElementById("progress-bar");
-const progressText = document.getElementById("progress-text");
-const eventLog = document.getElementById("event-log");
+const canvas = document.getElementById("canvas");
+const clearBtn = document.getElementById("clear-btn");
+const toolboxItems = document.querySelectorAll(".tool");
 
-const startBtn = document.getElementById("start-btn");
-const pauseBtn = document.getElementById("pause-btn");
-const resetBtn = document.getElementById("reset-btn");
-const clearLogBtn = document.getElementById("clear-log-btn");
+const labels = {
+  start: "开始",
+  task: "任务",
+  decision: "判断",
+  end: "结束",
+};
 
-let timer = null;
-let progress = 0;
-let runState = "idle";
+let idSeed = 1;
 
-function writeLog(message) {
-  const item = document.createElement("li");
-  const time = new Date().toLocaleTimeString("zh-CN", { hour12: false });
-  item.textContent = `[${time}] ${message}`;
-  eventLog.prepend(item);
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(value, max));
 }
 
-function render() {
-  progressBar.style.width = `${progress}%`;
-  progressText.textContent = `${progress}%`;
+function placeNode(type, x, y) {
+  const node = document.createElement("div");
+  node.className = `node node--${type}`;
+  node.textContent = `${labels[type]} ${idSeed++}`;
+  node.dataset.type = type;
+  node.draggable = true;
 
-  stateElement.className = "state";
-  if (runState === "running") {
-    stateElement.classList.add("state--running");
-    stateElement.textContent = "运行中";
-  } else if (runState === "paused") {
-    stateElement.classList.add("state--paused");
-    stateElement.textContent = "已暂停";
-  } else {
-    stateElement.classList.add("state--idle");
-    stateElement.textContent = "待机";
-  }
+  const width = 110;
+  const height = 40;
+  const left = clamp(x - width / 2, 0, canvas.clientWidth - width);
+  const top = clamp(y - height / 2, 0, canvas.clientHeight - height);
+  node.style.left = `${left}px`;
+  node.style.top = `${top}px`;
 
-  startBtn.disabled = runState === "running";
-  pauseBtn.disabled = runState !== "running";
+  node.addEventListener("dragstart", (event) => {
+    event.dataTransfer.setData("text/plain", "move-node");
+    event.dataTransfer.setData("node-id", node.dataset.nodeId);
+  });
+
+  node.dataset.nodeId = `node-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  canvas.appendChild(node);
 }
 
-function startFlow() {
-  if (runState === "running") {
-    return;
-  }
-  runState = "running";
-  writeLog("流程已启动");
-  timer = setInterval(() => {
-    progress = Math.min(progress + 5, 100);
-    if (progress >= 100) {
-      clearInterval(timer);
-      timer = null;
-      runState = "idle";
-      writeLog("流程执行完成");
-    }
-    render();
-  }, 650);
-  render();
-}
-
-function pauseFlow() {
-  if (runState !== "running") {
-    return;
-  }
-  clearInterval(timer);
-  timer = null;
-  runState = "paused";
-  writeLog("流程已暂停");
-  render();
-}
-
-function resetFlow() {
-  clearInterval(timer);
-  timer = null;
-  progress = 0;
-  runState = "idle";
-  writeLog("流程已重置");
-  render();
-}
-
-startBtn.addEventListener("click", startFlow);
-pauseBtn.addEventListener("click", pauseFlow);
-resetBtn.addEventListener("click", resetFlow);
-
-clearLogBtn.addEventListener("click", () => {
-  eventLog.innerHTML = "";
-  writeLog("日志已清空");
+toolboxItems.forEach((item) => {
+  item.addEventListener("dragstart", (event) => {
+    event.dataTransfer.setData("text/plain", "new-node");
+    event.dataTransfer.setData("node-type", item.dataset.type);
+  });
 });
 
-writeLog("面板已就绪");
-render();
+canvas.addEventListener("dragover", (event) => {
+  event.preventDefault();
+  canvas.classList.add("is-over");
+});
+
+canvas.addEventListener("dragleave", () => {
+  canvas.classList.remove("is-over");
+});
+
+canvas.addEventListener("drop", (event) => {
+  event.preventDefault();
+  canvas.classList.remove("is-over");
+
+  const rect = canvas.getBoundingClientRect();
+  const dropX = event.clientX - rect.left;
+  const dropY = event.clientY - rect.top;
+
+  const mode = event.dataTransfer.getData("text/plain");
+  if (mode === "new-node") {
+    const type = event.dataTransfer.getData("node-type");
+    if (labels[type]) {
+      placeNode(type, dropX, dropY);
+    }
+    return;
+  }
+
+  if (mode === "move-node") {
+    const nodeId = event.dataTransfer.getData("node-id");
+    const node = canvas.querySelector(`[data-node-id="${nodeId}"]`);
+    if (!node) {
+      return;
+    }
+
+    const width = node.offsetWidth;
+    const height = node.offsetHeight;
+    node.style.left = `${clamp(dropX - width / 2, 0, canvas.clientWidth - width)}px`;
+    node.style.top = `${clamp(dropY - height / 2, 0, canvas.clientHeight - height)}px`;
+  }
+});
+
+clearBtn.addEventListener("click", () => {
+  canvas.innerHTML = "";
+  idSeed = 1;
+});

--- a/style.css
+++ b/style.css
@@ -1,14 +1,11 @@
 :root {
-  color-scheme: light;
-  font-family: "PingFang SC", "Microsoft YaHei", system-ui, -apple-system, sans-serif;
-  --bg: #f5f7fb;
+  font-family: "PingFang SC", "Microsoft YaHei", system-ui, sans-serif;
+  --bg: #f4f7ff;
   --card: #ffffff;
-  --text: #15213a;
-  --muted: #5d6b86;
-  --primary: #377dff;
-  --border: #dbe3f1;
-  --success: #16a34a;
-  --warning: #f59e0b;
+  --line: #dce6ff;
+  --text: #1b2b49;
+  --muted: #5f7197;
+  --primary: #3867ff;
 }
 
 * {
@@ -17,153 +14,132 @@
 
 body {
   margin: 0;
-  background: var(--bg);
+  background: radial-gradient(circle at top right, #e9f0ff, var(--bg));
   color: var(--text);
 }
 
-.panel {
-  width: min(920px, 92vw);
-  margin: 3rem auto;
-  background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  padding: 1.2rem;
-  box-shadow: 0 10px 24px rgba(20, 40, 90, 0.08);
+.workflow-app {
+  width: min(1100px, 94vw);
+  margin: 2rem auto;
 }
 
-.panel__header h1 {
+.app-header h1 {
   margin: 0;
-  font-size: 1.5rem;
 }
 
-.panel__header p {
-  margin: 0.35rem 0 1rem;
+.app-header p {
+  margin: 0.5rem 0 1rem;
   color: var(--muted);
 }
 
-.status-grid {
+.layout {
   display: grid;
-  gap: 0.8rem;
-  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  grid-template-columns: 250px 1fr;
+  gap: 1rem;
 }
 
-.status-card {
-  border: 1px solid var(--border);
+.toolbox,
+.canvas-wrap {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 1rem;
+  box-shadow: 0 8px 24px rgba(56, 103, 255, 0.08);
+}
+
+.toolbox h2,
+.canvas-head h2 {
+  margin: 0 0 0.8rem;
+  font-size: 1rem;
+}
+
+.toolbox-list {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.tool {
+  border: 1px dashed #b7c8ff;
+  background: #f8faff;
+  padding: 0.65rem;
   border-radius: 10px;
-  padding: 0.75rem;
-  background: #fcfdff;
+  cursor: grab;
+  font-weight: 600;
+  color: #3453c7;
 }
 
-.status-card h2 {
-  margin: 0;
-  font-size: 0.95rem;
+.hint {
+  margin-top: 0.9rem;
+  font-size: 0.84rem;
   color: var(--muted);
 }
 
-.status-card p {
-  margin: 0.55rem 0 0;
-  font-size: 1.1rem;
-  font-weight: 600;
-}
-
-.state {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-
-.state::before {
-  content: "";
-  width: 0.55rem;
-  height: 0.55rem;
-  border-radius: 50%;
-  background: var(--muted);
-}
-
-.state--running::before {
-  background: var(--success);
-}
-
-.state--paused::before {
-  background: var(--warning);
-}
-
-.progress-wrap {
-  margin-top: 0.55rem;
-  height: 10px;
-  background: #e6ecf8;
-  border-radius: 99px;
-  overflow: hidden;
-}
-
-.progress-bar {
-  width: 0%;
-  height: 100%;
-  background: linear-gradient(90deg, #377dff, #2ec5ff);
-  transition: width 0.25s ease;
-}
-
-.controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.7rem;
-  margin: 1rem 0;
-}
-
-.btn {
-  border: 1px solid var(--border);
-  background: #fff;
-  color: var(--text);
-  padding: 0.55rem 1rem;
-  border-radius: 8px;
-  cursor: pointer;
-  font-weight: 600;
-}
-
-.btn:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
-
-.btn--primary {
-  border-color: transparent;
-  background: var(--primary);
-  color: #fff;
-}
-
-.btn--text {
-  padding: 0;
-  border: none;
-  color: var(--primary);
-}
-
-.log-section {
-  border-top: 1px solid var(--border);
-  padding-top: 1rem;
-}
-
-.log-section__head {
+.canvas-head {
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
 
-.log-section__head h2 {
-  margin: 0;
-  font-size: 1rem;
+.clear-btn {
+  border: none;
+  background: transparent;
+  color: var(--primary);
+  font-weight: 600;
+  cursor: pointer;
 }
 
-.event-log {
-  list-style: none;
-  margin: 0.75rem 0 0;
-  padding: 0;
-  max-height: 220px;
-  overflow: auto;
+.canvas {
+  position: relative;
+  height: 560px;
+  border: 2px dashed #bfd0ff;
+  border-radius: 12px;
+  background: linear-gradient(180deg, #fbfdff, #f5f9ff);
+  overflow: hidden;
 }
 
-.event-log li {
-  padding: 0.5rem 0;
-  border-bottom: 1px dashed #e6ecf8;
-  color: #273654;
-  font-size: 0.9rem;
+.canvas.is-over {
+  border-color: var(--primary);
+}
+
+.node {
+  position: absolute;
+  min-width: 96px;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  text-align: center;
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: move;
+  user-select: none;
+  box-shadow: 0 8px 16px rgba(28, 52, 128, 0.16);
+}
+
+.node--start {
+  background: #d1fae5;
+  color: #166534;
+}
+
+.node--task {
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.node--decision {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.node--end {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+@media (max-width: 860px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .canvas {
+    height: 420px;
+  }
 }


### PR DESCRIPTION
### Motivation
- Provide an interactive workflow modeling UI that lets users drag controls onto a canvas and reposition nodes to quickly build simple process diagrams.

### Description
- Replace the previous dashboard layout in `index.html` with a two-column layout containing a toolbox and a modeling canvas and remove the old status/progress/log sections.
- Add `style.css` updates to style the toolbox, canvas, node types (`start`, `task`, `decision`, `end`), drag-over highlighting, and responsive behavior.
- Implement drag-and-drop logic in `script.js` to create nodes by dragging from the toolbox, move nodes inside the canvas, clamp nodes to canvas boundaries, generate unique `data-node-id` values, and provide a clear-canvas reset with ID counter reset.
- Remove unused dashboard JS and related DOM references to reflect the new UI.

### Testing
- Ran `git status --short` to verify modified files were staged/changed successfully.
- Attempted to generate a headless screenshot with Playwright via `node -e "const { chromium } = require('playwright'); ..."` but the environment lacks the `playwright` package so the screenshot step failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35bdde7cc83279e94a74517abda1d)